### PR TITLE
doc updates; link to repo, add some refs, styling

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@ $ npm install -g bash-handbook
 
 You should be able to run `bash-handbook` at the command line now. This will open the manual in your selected `$PAGER`. Otherwise, you may continue reading on here.
 
+The source is available here: <https://github.com/denysdovhan/bash-handbook>
+
 # Table of Contents
 
 - [Introduction](#introduction)
@@ -57,9 +59,19 @@ You should be able to run `bash-handbook` at the command line now. This will ope
 
 If you are a developer, then you know the value of time. Optimizing your work process is one of the most important aspects of the job.
 
-In that path towards efficiency and productivity, we are often posed with actions that must be repeated over and over again, like taking a screenshot and uploading it to a server, processing text that may come in many shapes and forms, converting files between different formats, parsing a program's output and the list goes on. Enter bash, our savior.
+In that path towards efficiency and productivity, we are often posed with actions that must be repeated over and over again, like:
 
-**Bash** is a Unix shell written by [Brian Fox](https://en.wikipedia.org/wiki/Brian_Fox_(computer_programmer)) for the GNU Project as a free software replacement for the [Bourne shell](https://en.wikipedia.org/wiki/Bourne_shell). It was released in 1989 and has been distributed as the Linux and OS X default shell for a long time.
+* taking a screenshot and uploading it to a server
+* processing text that may come in many shapes and forms
+* converting files between different formats
+* parsing a program's output
+
+Enter **Bash**, our savior.
+
+Bash is a Unix shell written by [Brian Fox][] for the GNU Project as a free software replacement for the [Bourne shell](https://en.wikipedia.org/wiki/Bourne_shell). It was released in 1989 and has been distributed as the Linux and OS X default shell for a long time.
+
+[Brian Fox]: https://en.wikipedia.org/wiki/Brian_Fox_(computer_programmer)
+<!-- link this format, because some MD processors handle '()' in URLs poorly -->
 
 So why do we need to learn something that was written more than 30 years ago? The answer is simple: this _something_ is today one of the most powerful and portable tools for writing efficient scripts for all Unix-based systems. And that's why you should learn bash. Period.
 
@@ -791,6 +803,17 @@ This handbook narrates my own experience with Bash. It does not purport to be co
 Contributions are absolutely welcome and I will be grateful for any corrections or questions you can send my way. For all of that create a new [issue](https://github.com/denysdovhan/bash-handbook/issues).
 
 Thanks for reading this handbook!
+
+# Want to learn more?
+
+Here's a list of other literature covering Bash:
+
+* Bash man page.  In many environments that you can run Bash, the help system `man` can display information about Bash, by running the command `man bash`.  For more information on the `man` command, see the web page ["The man Command"](http://www.linfo.org/man.html) hosted at [The Linux Information Project](http://www.linfo.org/).
+
+* ["Bourne-Again SHell manual"](https://www.gnu.org/software/bash/manual/) in many formats, including HTML, Info, TeX, PDF, and Texinfo.  Hosted at <https://www.gnu.org/>.  As of 2016/01, this covers version 4.3, last updated 2015/02/02.
+
+* [Bash 3.2 Man page](https://developer.apple.com/library/mac/documentation/Darwin/Reference/ManPages/man1/bash.1.html) hosted at Apple's Mac Developer Library site.  As of 2016/01, this covers version 3.2, last updated 2006/09/28.
+
 
 # License
 


### PR DESCRIPTION
* added a link to the GitHub repo at the top of the doc; for the PDF version
  I generate, I'd like to provide a pointed to the repo at the very top of the
  doc.  This seemed like a good place.

* split the list of automation tasks for Bash targets into an actual list.

* moved "Enter Bash ..." to a new paragraph for emphasis.

* added a "Want to learn more?" section