### PR TITLE
Use `-eq` instead of `==` for numeric test

### DIFF
--- a/README.md
+++ b/README.md
@@ -762,7 +762,7 @@ The `continue` statement steps over one iteration. We can use it as such:
 
 ```bash
 for (( i = 0; i < 10; i++ )); do
-  if [[ $(($i % 2)) == 0 ]]; then continue; fi
+  if [[ $(($i % 2)) -eq 0 ]]; then continue; fi
   echo $i
 done
 ```


### PR DESCRIPTION
While `==` happens to work in this case, it's important to use `-eq`/`-neq` and `==`/`!=` in the appropriate situations.