### PR TITLE
Prefer arithmetic expansion to `expr`

### DIFF
--- a/README.md
+++ b/README.md
@@ -691,7 +691,7 @@ A working example might look like this:
 x=0
 while [[ $x -lt 10 ]]; do # value of x is less than 10
   echo $(($x*$x))
-  x=`expr $x + 1` # increase x
+  x=$(( $x + 1 )) # increase x
 done
 ```
 


### PR DESCRIPTION
The `while` loop example uses `expr` to increment a variable. This is correct and functions properly, but the `expr` command isn't introduced elsewhere in the handbook. I think it'd be easier to understand if implemented with arithmetic expansion instead:

```bash
x=0
while [[ $x -lt 10 ]]; do # value of x is less than 10
  echo $(($x*$x))
  x=$(( $x + 1 )) # increase x
done
```
