### PR TITLE
Launching from Terminal doesn't format properly

### DIFF
--- a/bin/cmd.js
+++ b/bin/cmd.js
@@ -29,6 +29,9 @@ var notifier = updateNotifier({
   pkg: pkg
 });
 
+process.env.PAGER = process.env.PAGER || 'less';
+process.env.LESS  = process.env.LESS  || 'FRX';
+
 fs.createReadStream(join(__dirname, '../README.md'))
   .pipe(obj(function (chunk, enc, cb) {
     var message = [];


### PR DESCRIPTION
```
$ sw_vers 
ProductName:	Mac OS X
ProductVersion:	10.11.3
BuildVersion:	15D21

$ bash --version
GNU bash, version 3.2.57(1)-release (x86_64-apple-darwin15)
Copyright (C) 2007 Free Software Foundation, Inc.
```

<img width="1082" alt="screen shot 2016-02-03 at 11 24 36" src="https://cloud.githubusercontent.com/assets/898057/12779659/807ff99a-ca69-11e5-9564-c5bbe7f6433e.png">

The following screenshot is taken after I press <kbd>Q</kbd> when in the pager, which I switched to less after the fact, without changes.
<img width="1082" alt="screen shot 2016-02-03 at 11 24 53" src="https://cloud.githubusercontent.com/assets/898057/12779665/840e4b20-ca69-11e5-853e-0e86b9ee403c.png">
