### PR TITLE
Upgrade to default-pager 1.1.0 to avoid EPIPE/ECONNRESET error message

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   "dependencies": {
     "boxen": "^0.2.0",
     "chalk": "^1.1.1",
-    "default-pager": "^1.0.2",
+    "default-pager": "^1.1.0",
     "msee": "^0.2.0",
     "through2": "^2.0.0",
     "update-notifier": "^0.6.0"


### PR DESCRIPTION
- Quitting the pager process (e.g., pressing 'q' in `less`) causes subsequent writes to the pipe to fail with EPIPE.
- default-pager release 1.1.0 adds a handler to ignore this error, avoiding a potentially confusing error message.