### PR TITLE
Add support for translations to cli

### DIFF
--- a/bin/cmd.js
+++ b/bin/cmd.js
@@ -9,6 +9,29 @@ var boxen = require('boxen');
 var chalk = require('chalk');
 var updateNotifier = require('update-notifier');
 var pkg = require('../package.json');
+var meow = require('meow');
+
+var cli = meow([
+  'Usage',
+  '  bash-handbook',
+  '',
+  'Options',
+  '  --lang, -l  Translation language',
+  '',
+  'Examples',
+  '  bash-handbook',
+  '  bash-handbook --lang pt-br'
+], {
+  string: [
+    'lang'
+  ],
+  alias: {
+    l: 'lang'
+  },
+  default: {
+    lang: ''
+  }
+});
 
 var boxenOpts = {
   borderColor: 'yellow',
@@ -32,17 +55,35 @@ var notifier = updateNotifier({
 process.env.PAGER = process.env.PAGER || 'less';
 process.env.LESS  = process.env.LESS  || 'FRX';
 
-fs.createReadStream(join(__dirname, '../README.md'))
-  .pipe(obj(function (chunk, enc, cb) {
-    var message = [];
+var lang = cli.flags.lang.toLowerCase()
+  .split('-')
+  .map(function (l, i) {
+    return i === 0 ? l : l.toUpperCase();
+  })
+  .join('-');
 
-    if (notifier.update) {
-      message.push('Update available: ' + chalk.green.bold(notifier.update.latest) + chalk.dim(' (current: ' + notifier.update.current + ')'));
-      message.push('Run ' + chalk.blue('npm install -g ' + pkg.name) + ' to update.');
-      this.push(boxen(message.join('\n'), boxenOpts));
-    }
+var translation = join(__dirname, !lang ?
+  '../README.md' :
+  '../translations/' + lang + '/README.md');
 
-    this.push(msee.parse(chunk.toString(), mseeOpts));
-    cb();
-  }))
-  .pipe(pager());
+fs.stat(translation, function (err, stats) {
+  if (err) {
+    console.log('The %s translation does not exist', chalk.bold(lang));
+    return;
+  }
+
+  fs.createReadStream(translation)
+    .pipe(obj(function (chunk, enc, cb) {
+      var message = [];
+
+      if (notifier.update) {
+        message.push('Update available: ' + chalk.green.bold(notifier.update.latest) + chalk.dim(' (current: ' + notifier.update.current + ')'));
+        message.push('Run ' + chalk.blue('npm install -g ' + pkg.name) + ' to update.');
+        this.push(boxen(message.join('\n'), boxenOpts));
+      }
+
+      this.push(msee.parse(chunk.toString(), mseeOpts));
+      cb();
+    }))
+    .pipe(pager());
+});

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "boxen": "^0.2.0",
     "chalk": "^1.1.1",
     "default-pager": "^1.1.0",
+    "meow": "^3.7.0",
     "msee": "^0.2.0",
     "through2": "^2.0.0",
     "update-notifier": "^0.6.0"


### PR DESCRIPTION
I added support for translations (#47) with `--lang` flag and structure `translations/<lang>`, like #57.