### PR TITLE
correction in example of default value for positional parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -264,7 +264,7 @@ Variables may also have _default_ values. We can define as such using the follow
 ```bash
  # if variables are empty, assign them default values
 : ${VAR:='default'}
-: ${$1:='first'}
+: ${1:='first'}
 # or
 FOO=${FOO:-'default'}
 ```


### PR DESCRIPTION
`${$1:='first'}` would give an error of `bad substitution` here. Changed it to `${1:='first'} `which does the job intended.