### PR TITLE
Add basic input validation to `select` example

### DIFF
--- a/README.md
+++ b/README.md
@@ -780,6 +780,12 @@ A working example might look like this:
 PS3="Choose the package manager: "
 select ITEM in bower npm gem pip
 do
+  # exit early if selection is invalid
+  if [[ -z "$ITEM" ]]; then
+      >&2 echo "Invalid selection"
+      exit 1
+  fi
+
   echo -n "Enter the package name: " && read PACKAGE
   case $ITEM in
     bower) bower install $PACKAGE ;;


### PR DESCRIPTION
Report an error message and exit early from select example if input is invalid.

Closes #129 